### PR TITLE
Character: Update the underlying models on death

### DIFF
--- a/src/db/models/CharacterModel.js
+++ b/src/db/models/CharacterModel.js
@@ -68,6 +68,7 @@ const characterSchema = new Schema({
     rightHand: { type: physicalLocationSchema },
     back: { type: physicalLocationSchema },
   },
+  isDead: { type: Boolean, default: false, },
 }, {
   timestamps: true,
 });


### PR DESCRIPTION
This patch updates our handling of death to do the following:

- If there is no accountId, then the character is an NPC. If so, we
  remove them from the underlying database.

- If there is an accountId, then for now we just set a new flag on
  the underlying CharacterModel, `isDead`.
  
Closes #1 