### PR TITLE
Combat: Send combat messages to the entire room

### DIFF
--- a/src/game/characters/Character.js
+++ b/src/game/characters/Character.js
@@ -468,7 +468,7 @@ class Character extends EventEmitter {
 
     const new_sub = this.mb.subscribe(this.room.id, (packet) => {
       // By default suppresss messages sent by yourself.
-      if (packet.sender && packet.sender === this.id) {
+      if (packet.senders && packet.senders.includes(this.id)) {
         if (!packet.options || !packet.options.sendToSelf) {
           log.debug({ characterId: this.id }, 'Suppressing message to self');
           return;

--- a/src/game/combat/Combat.js
+++ b/src/game/combat/Combat.js
@@ -123,6 +123,8 @@ class Combat {
     if (roll + this._calculateAttackerHitBonus() <= BASE_DEFENSE_SCORE + this._calculateDefenderDefenseBonus()) {
       this.attacker.sendImmediate(`You try to hit ${this.defender.toShortText()} but miss!`);
       this.defender.sendImmediate(`${this.attacker.toShortText()} swings at you but misses!`);
+      this.attacker.room.sendImmediate([ this.attacker, this.defender, ],
+        `${this.attacker.toShortText()} attempts to hit ${this.defender.toShortText()} but misses!`);
       return Combat.RESULT.CONTINUE;
     }
 
@@ -130,6 +132,8 @@ class Combat {
     this.defender.applyDamage(damage);
     this.attacker.sendImmediate(`You strike ${this.defender.toShortText()} for ${damage} points of damage!`);
     this.defender.sendImmediate(`${this.attacker.toShortText()} strikes you for ${damage} points of damage!`);
+    this.attacker.room.sendImmediate([ this.attacker, this.defender, ],
+      `${this.attacker.toShortText()} strikes ${this.defender.toShortText()} for ${damage} points of damage!`);
 
     if (this.defender.attributes.hitpoints.current === 0) {
       this.attacker.sendImmediate(`You have killed ${this.defender.toShortText()}`);

--- a/src/game/world/room.js
+++ b/src/game/world/room.js
@@ -116,12 +116,20 @@ class Room {
   /**
    * Send a message to the room
    *
-   * @param {Character} sender - The person sending the message
-   * @param {Object|String} message - The message to send
+   * @param {List<Character>} senders - The character or characters sending the message
+   * @param {Object|String} message   - The message to send
    */
-  sendImmediate(sender, message) {
+  sendImmediate(senders, message) {
+    let sendersArray;
+
+    if (!Array.isArray(sendersArray)) {
+      sendersArray = [ senders.id, ];
+    } else {
+      sendersArray = senders.map((sender) => sender.id);
+    }
+
     this.mb.publish(this.id, {
-      sender: sender.id,
+      senders: sendersArray,
       text: message
     });
   }

--- a/test/game/world/testRoom.js
+++ b/test/game/world/testRoom.js
@@ -196,7 +196,7 @@ describe('Room', () => {
       const uut = new Room(model);
       const sub = uut.mb.subscribe(uut.id, (payload) => {
         assert(payload);
-        assert(payload.sender === 'fake');
+        assert(payload.senders.includes('fake'));
         assert(payload.text === 'Test message');
         done();
       });


### PR DESCRIPTION
This patch updates combat so that when two characters are fighting,
the combat messages are broadcast to the rest of the participants in
the room. Because our existing `sendImmediate` function in a Room looks
for a single participant to see if we should exclude them, we've updated
the logic in room and Character to suppress messages based on lists. At
the same time, `sendImmediate` is now tolerant to both a list of `Character`
objects *or* a single `Character` being passed in.

Closes #6 