### PR TITLE
Combat: Add hit locations

### DIFF
--- a/src/game/characters/Character.js
+++ b/src/game/characters/Character.js
@@ -457,13 +457,13 @@ class Character extends EventEmitter {
 
       this.mb.unsubscribe(this._topics[this.room.id]);
       this._topics[this.room.id] = null;
-      this.room.sendImmediate(this,`${this.toShortText()} leaves`);
+      this.room.sendImmediate([this],`${this.toShortText()} leaves`);
       this.room.removeCharacter(this);
     }
 
     log.debug({ characterId: this.id, roomId: room.id }, 'Moving to room');
     this.room = room;
-    this.room.sendImmediate(this, `${this.toShortText()} enters`);
+    this.room.sendImmediate([this], `${this.toShortText()} enters`);
     this.room.addCharacter(this);
 
     const new_sub = this.mb.subscribe(this.room.id, (packet) => {

--- a/src/game/commands/default/DropItem.js
+++ b/src/game/commands/default/DropItem.js
@@ -42,7 +42,7 @@ class DropItemAction {
     }
     character.room.addItem(item);
     character.sendImmediate(`You drop ${item.name}`);
-    character.room.sendImmediate(character, `${character.name} drops ${item.name}`);
+    character.room.sendImmediate([character], `${character.name} drops ${item.name}`);
   }
 
 }

--- a/src/game/commands/default/GetItem.js
+++ b/src/game/commands/default/GetItem.js
@@ -86,7 +86,7 @@ class GetItemAction {
         character.addHauledItem(item);
         character.sendImmediate(`You put ${item.name} in your inventory`);
         if (container.sendImmediate) {
-          container.sendImmediate(character, `${character.name} picks up ${item.name}`);
+          container.sendImmediate([character], `${character.name} picks up ${item.name}`);
         }
       }
     });

--- a/src/game/commands/default/Look.js
+++ b/src/game/commands/default/Look.js
@@ -72,7 +72,7 @@ class LookAction {
           character.sendImmediate(`You do not see a ${this.target} here.`);
           return;
         }
-        character.room.sendImmediate(character, `${character.name} looks at ${this.target}`);
+        character.room.sendImmediate([character], `${character.name} looks at ${this.target}`);
       }
       character.sendImmediate(item.toLongText());
       return;

--- a/src/game/commands/default/RemoveItem.js
+++ b/src/game/commands/default/RemoveItem.js
@@ -85,7 +85,7 @@ class RemoveItemAction {
 
     character.addHauledItem(item);
     character.sendImmediate(`You stop ${verb} ${item.toShortText()} ${preposition} your ${physicalLocationToText(location)}`);
-    character.room.sendImmediate(character, `${character.toShortText()} stops ${verb} ${item.toShortText()} ${preposition} ${character.pronoun} ${physicalLocationToText(location)}`);
+    character.room.sendImmediate([character], `${character.toShortText()} stops ${verb} ${item.toShortText()} ${preposition} ${character.pronoun} ${physicalLocationToText(location)}`);
   }
 }
 

--- a/src/game/commands/default/WearItem.js
+++ b/src/game/commands/default/WearItem.js
@@ -95,7 +95,7 @@ class WearItemAction {
     }
 
     character.sendImmediate(`You ${verb} ${item.toShortText()} ${preposition} your ${physicalLocationToText(location)}`);
-    character.room.sendImmediate(character, `${character.toShortText()} ${verb}s ${item.toShortText()} ${preposition} ${character.pronoun} ${physicalLocationToText(location)}`);
+    character.room.sendImmediate([character], `${character.toShortText()} ${verb}s ${item.toShortText()} ${preposition} ${character.pronoun} ${physicalLocationToText(location)}`);
   }
 }
 

--- a/src/game/world/room.js
+++ b/src/game/world/room.js
@@ -116,17 +116,13 @@ class Room {
   /**
    * Send a message to the room
    *
-   * @param {List<Character>} senders - The character or characters sending the message
+   * @param {List<Character>} senders - The characters sending the message
    * @param {Object|String} message   - The message to send
    */
   sendImmediate(senders, message) {
     let sendersArray;
 
-    if (!Array.isArray(sendersArray)) {
-      sendersArray = [ senders.id, ];
-    } else {
-      sendersArray = senders.map((sender) => sender.id);
-    }
+    sendersArray = senders.map((sender) => sender.id);
 
     this.mb.publish(this.id, {
       senders: sendersArray,

--- a/test/game/world/testRoom.js
+++ b/test/game/world/testRoom.js
@@ -201,7 +201,7 @@ describe('Room', () => {
         done();
       });
       assert(sub);
-      uut.sendImmediate(fakeCharacter, 'Test message');
+      uut.sendImmediate([fakeCharacter], 'Test message');
     });
   });
 


### PR DESCRIPTION
This patch adds hit locations. Right now, this is just a text description of where
an attacker is targetting and, if it hits, where it hit the defender. Next step is
to add Armor Class.

We also updated the Room:sendImmediate function to not try and differentiate between
an array and a character. Both are objects, and Array.isArray wasn't quite working as
I hoped. Now we just require it to be an array, which is fine.

Closes #4 