### PR TITLE
Apply default attacks and/or weapon damage in Combat

### DIFF
--- a/src/db/models/CharacterModel.js
+++ b/src/db/models/CharacterModel.js
@@ -32,6 +32,16 @@ const modifiableAttributeSchema = new Schema({
   current: { type: Number },
 });
 
+const defaultAttackSchema = new Schema({
+  minDamage: { type: Number, default: 0 },
+  maxDamage: { type: Number, default: 1 },
+  damageType: { type: String, default: 'blundgeoning', enum: [ 'piercing', 'slashing', 'bludgeoning' ]},
+  verbs: {
+    firstPerson: { type: String, default: 'punch' },
+    thirdPerson: { type: String, default: 'punches' },
+  }
+});
+
 const characterSchema = new Schema({
   name: { type: String, required: true },
   accountId: { type: ObjectId },
@@ -69,6 +79,7 @@ const characterSchema = new Schema({
     back: { type: physicalLocationSchema },
   },
   isDead: { type: Boolean, default: false, },
+  defaultAttacks: [{ type: defaultAttackSchema }],
 }, {
   timestamps: true,
 });

--- a/src/game/characters/Character.js
+++ b/src/game/characters/Character.js
@@ -165,6 +165,46 @@ class Character extends EventEmitter {
   }
 
   /**
+   * Get the attacks for this character
+   *
+   * @return {Object} Weapon properties
+   * @return {Object.minDamage}
+   * @return {Object.maxDamage}
+   * @return {Object.damageType}
+   * @return {Object.verbs}
+   * @return {Object.verbs.firstPerson}
+   * @return {Object.verbs.thirdPerson}
+   */
+  get attacks() {
+    let attacks = [];
+
+    if (this.physicalLocations.leftHand.item || this.physicalLocations.rightHand.item) {
+      if (this.physicalLocations.rightHand.item && this.physicalLocations.rightHand.item.itemType === 'weapon') {
+        const weapon = this.physicalLocations.rightHand.item;
+        const attack = weapon.toAttack();
+        if (weapon.model.properties.includes('versatile') && !this.physicalLocations.leftHand.item) {
+          attack.maxDamage = attack.maxDamage * 1.5;
+        }
+        attacks.push(attack);
+      }
+
+      if (this.physicalLocations.leftHand.item && this.physicalLocations.leftHand.item.itemType === 'weapon') {
+        const weapon = this.physicalLocations.rightHand.item;
+        const attack = weapon.toAttack();
+        if (weapon.model.properties.includes('versatile') && !this.physicalLocations.rightHand.item) {
+          attack.maxDamage = attack.maxDamage * 1.5;
+        }
+        attacks.push(attack);
+      }
+    }
+
+    if (attacks.length === 0) {
+      attacks.push(...this.model.defaultAttacks);
+    }
+    return attacks;
+  }
+
+  /**
    * Handle a character dying.
    */
   async _handleDeath() {
@@ -570,6 +610,13 @@ class Character extends EventEmitter {
           this.addHauledItem(inanimate);
         }
       });
+    }
+
+    if (!this.model.defaultAttacks || this.model.defaultAttacks.length === 0) {
+      // Add a default attack
+      this.model.defaultAttacks = [
+        { minDamage: 0, maxDamage: 1, damageType: 'bludgeoning', verbs: { firstPerson: 'punch', thirdPerson: 'punches' }},
+      ];
     }
 
     // Find the Room and move us into it...

--- a/src/game/characters/factories/RatFactory.js
+++ b/src/game/characters/factories/RatFactory.js
@@ -56,6 +56,9 @@ class RatFactory {
       manapoints: { base: 0, current: 0 },
       energypoints: { base: 80, current: 80 },
     };
+    model.defaultAttacks = [
+      { minDamage: 0, maxDamage: 1, damageType: 'piercing', verbs: { firstPerson: 'bite', thirdPerson: 'bites' }}
+    ];
     await model.save();
 
     const rat = new Animal(model, this.world);

--- a/src/game/objects/Weapon.js
+++ b/src/game/objects/Weapon.js
@@ -101,6 +101,52 @@ class Weapon {
   }
 
   /**
+   * Verbs for the weapon's attack
+   *
+   * @returns {Object}
+   * @returns {Object.firstPerson}
+   * @returns {Object.thirdPerson}
+   */
+  get verbs() {
+    switch (this.model.damageType) {
+    case 'slashing':
+      return {
+        firstPerson: 'slash',
+        thirdPerson: 'slashes',
+      };
+    case 'piercing':
+      return {
+        firstPerson: 'pierce',
+        thirdPerson: 'pierces',
+      };
+    case 'bludgeoning':
+      return {
+        firstPerson: 'smash',
+        thirdPerson: 'smashes',
+      };
+    }
+    return {
+      firstPerson: 'swing',
+      thirdPerson: 'swinges',
+    };
+  }
+
+  /**
+   * Convert the weapon into a basic attack object useful for combat work
+   *
+   * @returns {Object}
+   */
+  toAttack() {
+    return {
+      minDamage: this.model.minDamage,
+      maxDamage: this.model.maxDamage,
+      verbs: this.verbs,
+      damageType: this.model.damageType,
+      name: this.model.name,
+    };
+  }
+
+  /**
    * A short description of the weapon
    *
    * @returns {String}

--- a/test/db/models/testCharacterModel.js
+++ b/test/db/models/testCharacterModel.js
@@ -82,6 +82,10 @@ describe('CharacterModel', () => {
         rightHand: { item: { inanimateId: new mongoose.Types.ObjectId(), inanimateType: 'weapon' } },
         back: { item: { inanimateId: new mongoose.Types.ObjectId(), inanimateType: 'armor' } },
       };
+      uut.defaultAttacks = [
+        { minDamage: 1, maxDamage: 5, damageType: 'piercing', verbs: { firstPerson: 'bite', thirdPerson: 'bites' }},
+        { minDamage: 2, maxDamage: 4, damageType: 'bludgeoning', verbs: { firstPerson: 'slam', thirdPerson: 'slams' }},
+      ];
       await uut.save();
       assert(uut);
     });

--- a/test/game/characters/factories/testRatFactory.js
+++ b/test/game/characters/factories/testRatFactory.js
@@ -30,6 +30,12 @@ describe('RatFactory', () => {
     assert(uut);
     const rat = await uut.generate();
     assert(rat);
+    assert(rat.attacks.length === 1);
+    assert(rat.attacks[0].minDamage === 0);
+    assert(rat.attacks[0].maxDamage === 1);
+    assert(rat.attacks[0].damageType === 'piercing');
+    assert(rat.attacks[0].verbs.firstPerson === 'bite');
+    assert(rat.attacks[0].verbs.thirdPerson === 'bites');
     assert(rat.room.id === room.id);
     assert(room.characters.find((c) => c.id === rat.id));
   });

--- a/test/game/commands/default/testAttack.js
+++ b/test/game/commands/default/testAttack.js
@@ -67,6 +67,9 @@ describe('AttackAction', () => {
         const uut = new AttackAction({ target: 'cat' });
         pc.transport.sentMessageCb = (msg) => {
           assert(msg);
+          if (msg === 'a cat enters') {
+            return;
+          }
           if (pc.transport.sentMessageCounter === 1) {
             assert.match(msg, /You attack a cat/);
           } else if (pc.transport.sentMessageCounter === 2) {

--- a/test/game/objects/testWeapons.js
+++ b/test/game/objects/testWeapons.js
@@ -33,6 +33,52 @@ import shortswordFactory from '../../../src/game/objects/factories/shortsword.js
 });
 
 describe('Weapon', () => {
+  [
+    { damageType: 'slashing', verbFirstPerson: 'slash', verbThirdPerson: 'slashes' },
+    { damageType: 'bludgeoning', verbFirstPerson: 'smash', verbThirdPerson: 'smashes' },
+    { damageType: 'piercing', verbFirstPerson: 'pierce', verbThirdPerson: 'pierces' },
+  ].forEach((damageTypeTest) => {
+    describe(damageTypeTest.damageType, () => {
+      let model;
+
+      beforeEach(async () => {
+        model = new WeaponModel();
+        model.name = 'Test';
+        model.description = 'A test weapon';
+        model.weight = 2;
+        model.minDamage = 10;
+        model.maxDamage = 20;
+        model.durability.current = 5;
+        model.durability.base = 10;
+        model.weaponType = 'simple';
+        model.damageType = damageTypeTest.damageType;
+        await model.save();
+      });
+
+      describe('verbs', () => {
+        it('returns the expected verb tenses', async () => {
+          const uut = new Weapon(model);
+          await uut.load();
+          assert(uut.verbs.firstPerson === damageTypeTest.verbFirstPerson);
+          assert(uut.verbs.thirdPerson === damageTypeTest.verbThirdPerson);
+        });
+      });
+
+      describe('attack', () => {
+        it('converts the weapon to basic attack object', async () => {
+          const uut = new Weapon(model);
+          await uut.load();
+          const attack = uut.toAttack();
+          assert(attack.verbs.firstPerson === damageTypeTest.verbFirstPerson);
+          assert(attack.verbs.thirdPerson === damageTypeTest.verbThirdPerson);
+          assert(attack.minDamage === uut.minDamage);
+          assert(attack.maxDamage === uut.maxDamage);
+          assert(attack.name === uut.name);
+        });
+      });
+    });
+  });
+
   describe('load', () => {
     afterEach(() => {
       WeaponModel.deleteMany();


### PR DESCRIPTION
This patch does two things:

First, it establishes default attacks on characters. This could be a punch,
a bite, or some combination thereof. Models set this up when created in a
generic fashion that act as a pseudo-lightweight weapon. Combat extracts this
from the player through a new 'attacks' method.

Second, Combat now respects weapons. Because the Combat module doesn't want
to make a lot of these determinations, it asks the Character for their attacks.
The Character makes the determination on what all attacks the Character can make
in that round and returns them.

Note that there's always going to be a bit of a dance between the two, as the
Combat module doesn't want to figure out if the Character is wielding two weapons
(and gets a penalty) or has a versatile weapon and is doing so with two hands.

Closes #5 