### PR TITLE
Put: Add the ability to put items into other items

### DIFF
--- a/src/game/characters/Character.js
+++ b/src/game/characters/Character.js
@@ -383,6 +383,7 @@ class Character extends EventEmitter {
 
     const item = this.physicalLocations[location].item;
     this.physicalLocations[location].item = null;
+    log.debug({ characterId: this.id, itemId: item.id }, `${this.name} is no longer wearing ${item.name} on ${location}`);
     return item;
   }
 
@@ -401,6 +402,7 @@ class Character extends EventEmitter {
       this.carryWeight -= oldWeight;
       this.carryWeight += newWeight;
     };
+    log.debug({ characterId: this.id, itemId: item.id }, `${this.name} is now hauling ${item.name}`);
     this.inanimates.addItem(item);
   }
 
@@ -418,6 +420,7 @@ class Character extends EventEmitter {
     }
     item.onWeightChangeCb = null;
     this.carryWeight -= item.weight;
+    log.debug({ characterId: this.id, itemId: item.id }, `${this.name} is no longer hauling ${item.name}`);
     return true;
   }
 

--- a/src/game/commands/CommandSet.js
+++ b/src/game/commands/CommandSet.js
@@ -14,6 +14,7 @@ import { GetItemFactory } from './default/GetItem.js';
 import { InventoryFactory } from './default/Inventory.js';
 import { LookFactory } from './default/Look.js';
 import { MoveFactory } from './default/Move.js';
+import { PutItemFactory } from './default/PutItem.js';
 import { RemoveItemFactory } from './default/RemoveItem.js';
 import { WearItemFactory } from './default/WearItem.js';
 
@@ -62,6 +63,7 @@ defaultCommandSet.commands[GetItemFactory.name] =  new GetItemFactory(defaultCom
 defaultCommandSet.commands[InventoryFactory.name] = new InventoryFactory(defaultCommandSet);
 defaultCommandSet.commands[LookFactory.name] = new LookFactory(defaultCommandSet);
 defaultCommandSet.commands[MoveFactory.name] = new MoveFactory(defaultCommandSet);
+defaultCommandSet.commands[PutItemFactory.name] = new PutItemFactory(defaultCommandSet);
 defaultCommandSet.commands[RemoveItemFactory.name] = new RemoveItemFactory(defaultCommandSet);
 defaultCommandSet.commands[WearItemFactory.name] = new WearItemFactory(defaultCommandSet);
 

--- a/src/game/commands/default/Error.js
+++ b/src/game/commands/default/Error.js
@@ -18,12 +18,15 @@ class ErrorAction {
   /**
    * Create a new Error
    *
-   * @param {String} command    - The command that the player tried to execute
-   * @param {String} parameters - The rest of the data
+   * @param {Object} params
+   * @param {String} params.message    - The message to send.
+   * @param {String} params.command    - The command that the player tried to execute
+   * @param {String} params.parameters - The rest of the data
    */
-  constructor(command, parameters) {
-    this.command = command;
-    this.parameters = parameters;
+  constructor(params) {
+    this.message = params.message;
+    this.command = params.command;
+    this.parameters = params.parameters;
   }
 
   /**
@@ -32,7 +35,11 @@ class ErrorAction {
    * @param {Character} character - The player to execute on
    */
   execute(character) {
-    character.sendImmediate(`You don't know how to '${this.command}'`);
+    if (this.message) {
+      character.sendImmediate(this.message);
+    } else {
+      character.sendImmediate(`You don't know how to '${this.command}'`);
+    }
   }
 
 }
@@ -59,7 +66,7 @@ class ErrorFactory {
    * Generate the DropItemAction from player input
    */
   generate(command, tokens = []) {
-    return new ErrorAction(command, tokens.join(' '));
+    return new ErrorAction({ command: command, parameters: tokens.join(' ') });
   }
 }
 

--- a/src/game/commands/default/PutItem.js
+++ b/src/game/commands/default/PutItem.js
@@ -1,0 +1,156 @@
+//------------------------------------------------------------------------------
+// MJMUD Backend
+// Copyright (C) 2022, Matt Jordan
+//
+// This program is free software, distributed under the terms of the
+// MIT License. See the LICENSE file at the top of the source tree.
+//------------------------------------------------------------------------------
+
+import { ErrorAction } from './Error.js';
+import Character from '../../characters/Character.js';
+import { inanimateNameComparitor } from '../../objects/inanimates.js';
+import { textToPhysicalLocation } from '../../../lib/physicalLocation.js';
+import log from '../../../lib/log.js';
+
+/**
+ * @module game/commands/default/Put
+ */
+
+/**
+ * An action that puts item into another item that the player carries
+ */
+class PutItemAction {
+
+  /**
+   * Create a new PutItemAction
+   *
+   * @param {String} source      - The object to move
+   * @param {String} destination - The object to put it into
+   * @param {String} [location]  - The object destination location
+   *
+   * @returns {PutItemAction}
+   */
+  constructor(source, destination, location = null) {
+    this.source = source;
+    this.destination = destination;
+    this.location = location;
+  }
+
+  /**
+   * Execute the action on the character
+   *
+   * @param {Character} character - The player character
+   */
+  execute(character) {
+    const sourceItem = character.inanimates.findItem(this.source);
+    if (!sourceItem) {
+      character.sendImmediate(`You are not carrying ${this.source}`);
+      return;
+    }
+
+    let destinationItem;
+    if (!this.location) {
+      destinationItem = character.inanimates.findItem(this.destination);
+      if (!destinationItem) {
+        character.sendImmediate(`You are not carrying ${this.destination}`);
+        return;
+      }
+    } else {
+      const locationName = textToPhysicalLocation(this.location);
+
+      if (!(Character.physicalLocations.includes(this.location))) {
+        character.sendImmediate(`${this.location} is not a valid location`);
+        return;
+      }
+
+      destinationItem = character.physicalLocations[locationName].item;
+      if (!destinationItem) {
+        character.sendImmediate(`You are not wearing anything on ${this.location}`);
+        return;
+      }
+      if (!inanimateNameComparitor(destinationItem.name, this.destination)) {
+        character.sendImmediate(`You are not wearing ${this.destination} on your ${this.location}`);
+        return;
+      }
+    }
+
+    if (!character.removeHauledItem(sourceItem)) {
+      log.warn({ characterId: character.id, sourceItemId: sourceItem.id }, 'Failed to remove hauled item');
+      return;
+    }
+    if (!destinationItem.addItem(sourceItem)) {
+      character.sendImmediate(`You cannot put ${sourceItem.toShortText()} in ${destinationItem.toShortText()}`);
+      character.addHauledItem(sourceItem);
+      return;
+    } else {
+      character.sendImmediate(`You put ${sourceItem.toShortText()} in ${destinationItem.toShortText()}`);
+    }
+
+  }
+}
+
+/**
+ * Factory that generates PutItemAction objects
+ */
+class PutItemFactory {
+  /**
+   * The mapping of this factory to the player command
+   *
+   * @return {String}
+   */
+  static get name() {
+    return 'put';
+  }
+
+  /**
+   * Create a new factory
+   */
+  constructor() {
+  }
+
+  /**
+   * Generate a MoveAction from the provided player input
+   *
+   * @param {Array.<String>} tokens - The text the player provided
+   *
+   * @return {MoveAction} On success, the action to execute, or null
+   */
+  generate(tokens) {
+    if (tokens.length === 0) {
+      return null;
+    }
+
+    const index = tokens.indexOf('in');
+    if (index === -1) {
+      return new ErrorAction({ message: `What do you want to put ${tokens.join(' ')} in?` });
+    }
+
+    const source = tokens.slice(0, index);
+    let destination = tokens.slice(index + 1, tokens.length);
+    if (!source || source.length === 0) {
+      return new ErrorAction({ message: `What do you want to put in ${destination.join(' ')}?` });
+    }
+    if (!destination || destination.length === 0) {
+      return new ErrorAction({ message: `What do you want to put ${source.join(' ')} in?` });
+    }
+
+    const locIndex = destination.indexOf('on');
+    let location = [];
+    if (locIndex !== -1) {
+      location = destination.slice(locIndex + 1, destination.length);
+      destination = destination.slice(0, locIndex);
+
+      if (!location || location.length === 0) {
+        return new ErrorAction({ message: `What ${destination.join(' ')} do you want to put ${source.join(' ')} in?` });
+      }
+    }
+
+    return new PutItemAction(source.join(' '), destination.join(' '), location.join(' '));
+  }
+
+}
+
+export {
+  PutItemAction,
+  PutItemFactory,
+};

--- a/src/game/objects/factories/backpack.js
+++ b/src/game/objects/factories/backpack.js
@@ -20,7 +20,7 @@ import Armor from '../Armor.js';
  */
 const backpackFactory = async () => {
   const model = new ArmorModel();
-  model.name = 'Backpack';
+  model.name = 'backpack';
   model.description = 'A backpack, useful for carrying things.';
   model.weight = 1;
   model.dexterityPenalty = 0;

--- a/src/game/objects/factories/longsword.js
+++ b/src/game/objects/factories/longsword.js
@@ -20,7 +20,7 @@ import Weapon from '../Weapon.js';
  */
 const longswordFactory = async () => {
   const model = new WeaponModel();
-  model.name = 'Longsword';
+  model.name = 'longsword';
   model.description = 'A sword with both a long blade and grip, allowing both one and two-handed use.';
   model.properties.push('versatile');
   model.damageType = 'slashing';

--- a/src/game/objects/factories/mace.js
+++ b/src/game/objects/factories/mace.js
@@ -20,7 +20,7 @@ import Weapon from '../Weapon.js';
  */
 const maceFactory = async () => {
   const model = new WeaponModel();
-  model.name = 'Mace';
+  model.name = 'mace';
   model.description = 'A blunt weapon with a heavy head on the end of a metal handle.';
   model.damageType = 'bludgeoning';
   model.weaponType = 'simple';

--- a/src/game/objects/factories/ring.js
+++ b/src/game/objects/factories/ring.js
@@ -20,7 +20,7 @@ import Armor from '../Armor.js';
  */
 const ringFactory = async () => {
   const model = new ArmorModel();
-  model.name = 'Ring';
+  model.name = 'ring';
   model.description = 'A small metal band worn on a finger.';
   model.weight = 0;
   model.dexterityPenalty = 0;

--- a/src/game/objects/factories/shirt.js
+++ b/src/game/objects/factories/shirt.js
@@ -20,7 +20,7 @@ import Armor from '../Armor.js';
  */
 const shirtFactory = async () => {
   const model = new ArmorModel();
-  model.name = 'Shirt';
+  model.name = 'shirt';
   model.description = 'A well-made cloth shirt.';
   model.weight = 0.25;
   model.dexterityPenalty = 0;

--- a/src/game/objects/factories/shortsword.js
+++ b/src/game/objects/factories/shortsword.js
@@ -20,7 +20,7 @@ import Weapon from '../Weapon.js';
  */
 const shortswordFactory = async () => {
   const model = new WeaponModel();
-  model.name = 'Shortsword';
+  model.name = 'shortsword';
   model.description = 'A light one-handed sword used for thrusting.';
   model.properties.push('light');
   model.properties.push('finesse');

--- a/test/game/commands/default/testAttack.js
+++ b/test/game/commands/default/testAttack.js
@@ -63,27 +63,6 @@ describe('AttackAction', () => {
     });
 
     describe('when the character exists', () => {
-      it('does not start an attack twice', (done) => {
-        const uut = new AttackAction({ target: 'cat' });
-        pc.transport.sentMessageCb = (msg) => {
-          assert(msg);
-          if (msg === 'a cat enters') {
-            return;
-          }
-          if (pc.transport.sentMessageCounter === 1) {
-            assert.match(msg, /You attack a cat/);
-          } else if (pc.transport.sentMessageCounter === 2) {
-            assert.match(msg, /You/);
-          } else if (pc.transport.sentMessageCounter === 3) {
-            assert.match(msg, /You are already attacking/);
-            done();
-          }
-        };
-        uut.execute(pc);
-        uut.execute(pc);
-      });
-
-
       it('starts the combat by swinging away', (done) => {
         const uut = new AttackAction({ target: 'cat' });
         pc.transport.sentMessageCb = (msg) => {

--- a/test/game/commands/default/testDropItem.js
+++ b/test/game/commands/default/testDropItem.js
@@ -29,10 +29,10 @@ describe('DropItemAction', () => {
 
   describe('when the item is not in the player inventory', () => {
     it('tells them it does not exist', async () => {
-      const uut = new DropItemAction('Backpack');
+      const uut = new DropItemAction('backpack');
       await uut.execute(pc);
       assert(pc.transport.sentMessages.length === 1);
-      assert.match(pc.transport.sentMessages[0], /You do not have Backpack/);
+      assert.match(pc.transport.sentMessages[0], /You do not have backpack/);
       assert(pc.inanimates.length === 1);
       assert(pc.room.inanimates.length === 0);
     });
@@ -40,10 +40,10 @@ describe('DropItemAction', () => {
 
   describe('when the item is in the player inventory', () => {
     it('drops it on the floor of the room', async () => {
-      const uut = new DropItemAction('Longsword');
+      const uut = new DropItemAction('longsword');
       await uut.execute(pc);
       assert(pc.transport.sentMessages.length === 1);
-      assert.match(pc.transport.sentMessages[0], /You drop Longsword/);
+      assert.match(pc.transport.sentMessages[0], /You drop longsword/);
       assert(pc.inanimates.length === 0);
       assert(pc.room.inanimates.length === 1);
     });

--- a/test/game/commands/default/testError.js
+++ b/test/game/commands/default/testError.js
@@ -11,8 +11,19 @@ import assert from 'power-assert';
 import { ErrorAction, ErrorFactory } from '../../../../src/game/commands/default/Error.js';
 
 describe('ErrorAction', () => {
+  it('defers to using message if available', (done) => {
+    const uut = new ErrorAction({ message: 'foobar', command: 'foo' });
+    uut.execute({
+      sendImmediate: (msg) => {
+        assert(msg);
+        assert(msg === 'foobar');
+        done();
+      }
+    });
+  });
+
   it('sends the expected error to the character', (done) => {
-    const uut = new ErrorAction('foo', []);
+    const uut = new ErrorAction({ command: 'foo', parameters: [] });
     uut.execute({
       sendImmediate: (msg) => {
         assert(msg);

--- a/test/game/commands/default/testGetItem.js
+++ b/test/game/commands/default/testGetItem.js
@@ -29,10 +29,10 @@ describe('GetItemAction', () => {
 
   describe('when the item does not exist', () => {
     it('tells the player that the item does not exist', async () => {
-      const uut = new GetItemAction('Longsword');
+      const uut = new GetItemAction('longsword');
       await uut.execute(pc);
       assert(pc.transport.sentMessages.length === 1);
-      assert.match(pc.transport.sentMessages[0], /Longsword is not in/);
+      assert.match(pc.transport.sentMessages[0], /longsword is not in/);
     });
   });
 
@@ -43,10 +43,10 @@ describe('GetItemAction', () => {
     });
 
     it('tells the player that the container does not exist', async () => {
-      const uut = new GetItemAction('Longsword', 'Backpack');
+      const uut = new GetItemAction('longsword', 'backpack');
       await uut.execute(pc);
       assert(pc.transport.sentMessages.length === 1);
-      assert.match(pc.transport.sentMessages[0], /Backpack does not exist/);
+      assert.match(pc.transport.sentMessages[0], /backpack does not exist/);
     });
   });
 
@@ -63,8 +63,8 @@ describe('GetItemAction', () => {
         const uut = new GetItemAction('all');
         await uut.execute(pc);
         assert(pc.transport.sentMessages.length === 2);
-        assert.match(pc.transport.sentMessages[0], /You put Longsword in your inventory/);
-        assert.match(pc.transport.sentMessages[1], /You put Longsword in your inventory/);
+        assert.match(pc.transport.sentMessages[0], /You put longsword in your inventory/);
+        assert.match(pc.transport.sentMessages[1], /You put longsword in your inventory/);
         assert(pc.inanimates.length === 2);
       });
     });
@@ -89,8 +89,8 @@ describe('GetItemAction', () => {
           const uut = new GetItemAction('all', 'Backpack');
           await uut.execute(pc);
           assert(pc.transport.sentMessages.length === 2);
-          assert.match(pc.transport.sentMessages[0], /You put Longsword in your inventory/);
-          assert.match(pc.transport.sentMessages[1], /You put Longsword in your inventory/);
+          assert.match(pc.transport.sentMessages[0], /You put longsword in your inventory/);
+          assert.match(pc.transport.sentMessages[1], /You put longsword in your inventory/);
           assert(pc.inanimates.length === 2);
         });
       });
@@ -104,8 +104,8 @@ describe('GetItemAction', () => {
           const uut = new GetItemAction('all', 'Backpack');
           await uut.execute(pc);
           assert(pc.transport.sentMessages.length === 2);
-          assert.match(pc.transport.sentMessages[0], /You put Longsword in your inventory/);
-          assert.match(pc.transport.sentMessages[1], /You put Longsword in your inventory/);
+          assert.match(pc.transport.sentMessages[0], /You put longsword in your inventory/);
+          assert.match(pc.transport.sentMessages[1], /You put longsword in your inventory/);
           assert(pc.inanimates.length === 2);
         });
       });
@@ -119,8 +119,8 @@ describe('GetItemAction', () => {
           const uut = new GetItemAction('all', 'Backpack');
           await uut.execute(pc);
           assert(pc.transport.sentMessages.length === 2);
-          assert.match(pc.transport.sentMessages[0], /You put Longsword in your inventory/);
-          assert.match(pc.transport.sentMessages[1], /You put Longsword in your inventory/);
+          assert.match(pc.transport.sentMessages[0], /You put longsword in your inventory/);
+          assert.match(pc.transport.sentMessages[1], /You put longsword in your inventory/);
           assert(pc.inanimates.length === 3);
         });
       });
@@ -135,10 +135,10 @@ describe('GetItemAction', () => {
       });
 
       it('the player picks it up', async () => {
-        const uut = new GetItemAction('Longsword');
+        const uut = new GetItemAction('longsword');
         await uut.execute(pc);
         assert(pc.transport.sentMessages.length === 1);
-        assert.match(pc.transport.sentMessages[0], /You put Longsword in your inventory/);
+        assert.match(pc.transport.sentMessages[0], /You put longsword in your inventory/);
         assert(pc.inanimates.length === 1);
       });
     });
@@ -158,10 +158,10 @@ describe('GetItemAction', () => {
         });
 
         it('the player picks it up', async () => {
-          const uut = new GetItemAction('Longsword', 'Backpack');
+          const uut = new GetItemAction('longsword', 'Backpack');
           await uut.execute(pc);
           assert(pc.transport.sentMessages.length === 1);
-          assert.match(pc.transport.sentMessages[0], /You put Longsword in your inventory/);
+          assert.match(pc.transport.sentMessages[0], /You put longsword in your inventory/);
           assert(pc.inanimates.length === 1);
         });
       });
@@ -172,10 +172,10 @@ describe('GetItemAction', () => {
         });
 
         it('the player picks it up', async () => {
-          const uut = new GetItemAction('Longsword', 'Backpack');
+          const uut = new GetItemAction('longsword', 'Backpack');
           await uut.execute(pc);
           assert(pc.transport.sentMessages.length === 1);
-          assert.match(pc.transport.sentMessages[0], /You put Longsword in your inventory/);
+          assert.match(pc.transport.sentMessages[0], /You put longsword in your inventory/);
           assert(pc.inanimates.length === 1);
         });
       });
@@ -186,10 +186,10 @@ describe('GetItemAction', () => {
         });
 
         it('the player picks it up', async () => {
-          const uut = new GetItemAction('Longsword', 'Backpack');
+          const uut = new GetItemAction('longsword', 'Backpack');
           await uut.execute(pc);
           assert(pc.transport.sentMessages.length === 1);
-          assert.match(pc.transport.sentMessages[0], /You put Longsword in your inventory/);
+          assert.match(pc.transport.sentMessages[0], /You put longsword in your inventory/);
           assert(pc.inanimates.length === 2);
         });
       });

--- a/test/game/commands/default/testLook.js
+++ b/test/game/commands/default/testLook.js
@@ -188,10 +188,10 @@ describe('LookAction', () => {
   describe('objects', () => {
     describe('when the object does not exist', () => {
       it('tells the player that they do not see it', (done) => {
-        const action = new LookAction({ target: 'Shirt' });
+        const action = new LookAction({ target: 'shirt' });
         const transport = new FakeClient((msg) => {
           assert(msg);
-          assert.match(msg, /You do not see a Shirt here/);
+          assert.match(msg, /You do not see a shirt here/);
           done();
         });
         pc.transport = transport;
@@ -202,7 +202,7 @@ describe('LookAction', () => {
     describe('when the object exists', () => {
       describe('case sensitive', () => {
         it('returns a description', (done) => {
-          const action = new LookAction({ target: 'Ring' });
+          const action = new LookAction({ target: 'ring' });
           const transport = new FakeClient((msg) => {
             assert(msg);
             assert.match(msg, /A small metal band worn on a finger/);

--- a/test/game/commands/default/testPutItem.js
+++ b/test/game/commands/default/testPutItem.js
@@ -1,0 +1,204 @@
+//------------------------------------------------------------------------------
+// MJMUD Backend
+// Copyright (C) 2022, Matt Jordan
+//
+// This program is free software, distributed under the terms of the
+// MIT License. See the LICENSE file at the top of the source tree.
+//------------------------------------------------------------------------------
+
+import assert from 'power-assert';
+
+import ArmorModel from '../../../../src/db/models/ArmorModel.js';
+import Armor from '../../../../src/game/objects/Armor.js';
+import { FakeClient, createWorld, destroyWorld } from '../../fixtures.js';
+import backpackFactory from '../../../../src/game/objects/factories/backpack.js';
+import maceFactory from '../../../../src/game/objects/factories/mace.js';
+import { PutItemFactory, PutItemAction } from '../../../../src/game/commands/default/PutItem.js';
+
+
+describe('PutItemAction', () => {
+  let pc;
+
+  beforeEach(async () => {
+    const results = await createWorld();
+    pc = results.pc1;
+    pc.transport = new FakeClient();
+
+    const backpack = await backpackFactory();
+    pc.addHauledItem(backpack);
+    const mace = await maceFactory();
+    pc.addHauledItem(mace);
+  });
+
+  afterEach(async () => {
+    await destroyWorld();
+  });
+
+  describe('when the source is not in the inventory', () => {
+    it('complains', () => {
+      const uut = new PutItemAction('ring', 'backpack');
+      uut.execute(pc);
+      assert(pc.transport.sentMessages.length === 1);
+      assert.match(pc.transport.sentMessages[0], /You are not carrying ring/);
+    });
+  });
+
+  describe('when the destination is not available', () => {
+    it('complains', () => {
+      const uut = new PutItemAction('mace', 'bag');
+      uut.execute(pc);
+      assert(pc.transport.sentMessages.length === 1);
+      assert.match(pc.transport.sentMessages[0], /You are not carrying bag/);
+    });
+  });
+
+  describe('when the destination is in the inventory', () => {
+    it('puts the item into the destination', () => {
+      const uut = new PutItemAction('mace', 'backpack');
+      uut.execute(pc);
+      assert(pc.transport.sentMessages.length === 1);
+      assert.match(pc.transport.sentMessages[0], /You put mace in backpack/);
+    });
+  });
+
+  describe('when the destination is worn', () => {
+    ['head', 'body', 'neck', 'hands', 'legs', 'feet', 'leftFinger', 'rightFinger', 'leftHand', 'rightHand', 'back'].forEach((location) => {
+      describe(`on ${location}`, () => {
+        beforeEach(async () => {
+          const model = new ArmorModel();
+          model.name = 'container';
+          model.description = 'A test container';
+          model.weight = 1;
+          model.dexterityPenalty = 0;
+          model.armorClass = 0;
+          model.wearableLocations.push(location);
+          model.isContainer = true;
+          model.containerProperties.weightCapacity = 40;
+          model.durability.current = 10;
+          model.durability.base = 10;
+          await model.save();
+
+          const armor = new Armor(model);
+          await armor.load();
+
+          pc.physicalLocations[location].item = armor;
+        });
+
+        it('complains if you aren not wearing anything there', () => {
+          const badLocation = location !== 'back' ? 'back' : 'body';
+          const uut = new PutItemAction('mace', 'container', badLocation);
+          uut.execute(pc);
+          assert(pc.transport.sentMessages.length === 1);
+          assert.match(pc.transport.sentMessages[0], /You are not wearing anything on/);
+        });
+
+        describe('wrong named container', () => {
+          beforeEach(async () => {
+            const badLocation = location !== 'back' ? 'back' : 'body';
+            const model = new ArmorModel();
+            model.name = 'watcontainer';
+            model.description = 'A test container';
+            model.weight = 1;
+            model.dexterityPenalty = 0;
+            model.armorClass = 0;
+            model.wearableLocations.push(badLocation);
+            model.isContainer = true;
+            model.containerProperties.weightCapacity = 40;
+            model.durability.current = 10;
+            model.durability.base = 10;
+            await model.save();
+
+            const armor = new Armor(model);
+            await armor.load();
+
+            pc.physicalLocations[badLocation].item = armor;
+          });
+
+          it('complains if the location is wrong', () => {
+            const badLocation = location !== 'back' ? 'back' : 'body';
+            const uut = new PutItemAction('mace', 'container', badLocation);
+            uut.execute(pc);
+            assert(pc.transport.sentMessages.length === 1);
+            assert.match(pc.transport.sentMessages[0], /You are not wearing container on your/);
+          });
+        });
+
+        it('puts the item into the destination', () => {
+          const uut = new PutItemAction('mace', 'container', location);
+          uut.execute(pc);
+          assert(pc.transport.sentMessages.length === 1);
+          assert.match(pc.transport.sentMessages[0], /You put mace in container/);
+        });
+      });
+    });
+  });
+});
+
+describe('PutItemFactory', () => {
+  describe('when generating an action', () => {
+    it('handles an empty list', () => {
+      const uut = new PutItemFactory();
+      const result = uut.generate([]);
+      assert(result === null);
+    });
+
+    describe('when the source is not specified', () => {
+      it('complains', () => {
+        const uut = new PutItemFactory();
+        const result = uut.generate(['in', 'backpack']);
+        assert(result);
+        assert(result.message === 'What do you want to put in backpack?');
+      });
+    });
+
+    describe('when the target is not specified', () => {
+      it('complains', () => {
+        const uut = new PutItemFactory();
+        const result = uut.generate(['longsword']);
+        assert(result);
+        assert(result.message === 'What do you want to put longsword in?');
+      });
+
+      it('still complains', () => {
+        const uut = new PutItemFactory();
+        const result = uut.generate(['longsword', 'in']);
+        assert(result);
+        assert(result.message === 'What do you want to put longsword in?');
+      });
+    });
+
+    describe('when the location is specified', () => {
+      it('but incorrectly it complains', () => {
+        const uut = new PutItemFactory();
+        const result = uut.generate(['longsword', 'in', 'backpack', 'on']);
+        assert(result);
+        assert(result.message === 'What backpack do you want to put longsword in?');
+      });
+
+      it('correctly it set it up', () => {
+        const uut = new PutItemFactory();
+        const result = uut.generate(['longsword', 'in', 'backpack', 'on', 'back']);
+        assert(result);
+        assert(result.source === 'longsword');
+        assert(result.destination === 'backpack');
+        assert(result.location === 'back');
+      });
+    });
+
+    it('handles simple item sources and destinations', () => {
+      const uut = new PutItemFactory();
+      const result = uut.generate(['longsword', 'in', 'backpack']);
+      assert(result);
+      assert(result.source === 'longsword');
+      assert(result.destination === 'backpack');
+    });
+
+    it('handles complex item sources and destinations', () => {
+      const uut = new PutItemFactory();
+      const result = uut.generate(['sharp', 'longsword', 'in', 'large', 'backpack']);
+      assert(result);
+      assert(result.source === 'sharp longsword');
+      assert(result.destination === 'large backpack');
+    });
+  });
+});

--- a/test/game/commands/default/testRemoveItem.js
+++ b/test/game/commands/default/testRemoveItem.js
@@ -45,10 +45,10 @@ describe('RemoveItemAction', () => {
 
     describe('in the location specified', async () => {
       it('tells them that they are not wearing it', async () => {
-        const uut = new RemoveItemAction('Ring', 'body');
+        const uut = new RemoveItemAction('ring', 'body');
         await uut.execute(pc);
         assert(pc.transport.sentMessages.length === 1);
-        assert.match(pc.transport.sentMessages[0], /You are not wearing Ring on your body/);
+        assert.match(pc.transport.sentMessages[0], /You are not wearing ring on your body/);
         assert(pc.inanimates.length === 0);
       });
     });
@@ -56,22 +56,22 @@ describe('RemoveItemAction', () => {
 
   describe('when the item is ambiguous', () => {
     it('tells the player to be more specific', async () => {
-      const uut = new RemoveItemAction('Ring');
+      const uut = new RemoveItemAction('ring');
       await uut.execute(pc);
       assert(pc.transport.sentMessages.length === 1);
-      assert.match(pc.transport.sentMessages[0], /Which Ring/);
+      assert.match(pc.transport.sentMessages[0], /Which ring/);
       assert(pc.inanimates.length === 0);
     });
   });
 
   describe('when the player is specific', () => {
     it('removes the correct item and puts it in the player inventory', async () => {
-      const uut = new RemoveItemAction('Ring', 'left finger');
+      const uut = new RemoveItemAction('ring', 'left finger');
       await uut.execute(pc);
       assert(pc.transport.sentMessages.length === 1);
-      assert.match(pc.transport.sentMessages[0], /You stop wearing Ring on your left finger/);
+      assert.match(pc.transport.sentMessages[0], /You stop wearing ring on your left finger/);
       assert(pc.inanimates.length === 1);
-      assert(pc.inanimates.all[0].name === 'Ring');
+      assert(pc.inanimates.all[0].name === 'ring');
     });
   });
 });

--- a/test/game/commands/default/testWearItem.js
+++ b/test/game/commands/default/testWearItem.js
@@ -43,30 +43,30 @@ describe('WearItemAction', () => {
   describe('when the location is ambiguous', () => {
     describe('and the player has not given direction', () => {
       it('tells the player to be more specific', async () => {
-        const uut = new WearItemAction('Ring');
+        const uut = new WearItemAction('ring');
         await uut.execute(pc);
         assert(pc.transport.sentMessages.length === 1);
-        assert.match(pc.transport.sentMessages[0], /Where would you like to wear Ring/);
+        assert.match(pc.transport.sentMessages[0], /Where would you like to wear ring/);
         assert(pc.inanimates.length === 2);
       });
     });
 
     describe('and the player provides an invalid location', () => {
       it('tells the player that it is invalid', async () => {
-        const uut = new WearItemAction('Ring', 'body');
+        const uut = new WearItemAction('ring', 'body');
         await uut.execute(pc);
         assert(pc.transport.sentMessages.length === 1);
-        assert.match(pc.transport.sentMessages[0], /You cannot wear Ring on your body/);
+        assert.match(pc.transport.sentMessages[0], /You cannot wear ring on your body/);
         assert(pc.inanimates.length === 2);
       });
     });
 
     describe('and the player provides a valid location', () => {
       it('wears the item', async () => {
-        const uut = new WearItemAction('Ring', 'left finger');
+        const uut = new WearItemAction('ring', 'left finger');
         await uut.execute(pc);
         assert(pc.transport.sentMessages.length === 1);
-        assert.match(pc.transport.sentMessages[0], /You put Ring on your left finger/);
+        assert.match(pc.transport.sentMessages[0], /You put ring on your left finger/);
         assert(pc.inanimates.length === 1);
       });
     });
@@ -75,20 +75,20 @@ describe('WearItemAction', () => {
   describe('when the location is not ambiguous', () => {
     describe('but the player is silly and specifies a location', () => {
       it('tells the player that they are not making sense', async () => {
-        const uut = new WearItemAction('Shirt', 'left finger');
+        const uut = new WearItemAction('shirt', 'left finger');
         await uut.execute(pc);
         assert(pc.transport.sentMessages.length === 1);
-        assert.match(pc.transport.sentMessages[0], /You cannot wear Shirt on your left finger/);
+        assert.match(pc.transport.sentMessages[0], /You cannot wear shirt on your left finger/);
         assert(pc.inanimates.length === 2);
       });
     });
 
     describe('because there is only one place to wear the item', () => {
       it('puts the correct item on the player', async () => {
-        const uut = new WearItemAction('Shirt');
+        const uut = new WearItemAction('shirt');
         await uut.execute(pc);
         assert(pc.transport.sentMessages.length === 1);
-        assert.match(pc.transport.sentMessages[0], /You put Shirt on your body/);
+        assert.match(pc.transport.sentMessages[0], /You put shirt on your body/);
         assert(pc.inanimates.length === 1);
         assert(pc.physicalLocations.body.item);
       });
@@ -101,10 +101,10 @@ describe('WearItemAction', () => {
       });
 
       it('figures out the right place to put the item', async () => {
-        const uut = new WearItemAction('Ring');
+        const uut = new WearItemAction('ring');
         await uut.execute(pc);
         assert(pc.transport.sentMessages.length === 1);
-        assert.match(pc.transport.sentMessages[0], /You put Ring on your right finger/);
+        assert.match(pc.transport.sentMessages[0], /You put ring on your right finger/);
         assert(pc.inanimates.length === 1);
         assert(pc.physicalLocations.rightFinger.item);
       });


### PR DESCRIPTION
Characters have the ability to wear or haul around containers. While we can `get`
items from them today, we can't put items into them.

This patch adds the ability for a player to put an item into another item. Players can
put items into an item that they are hauling or wearing.

Issue #18 