### PR TITLE
Room: Break up loads into two passes

### DIFF
--- a/src/game/world/Area.js
+++ b/src/game/world/Area.js
@@ -75,8 +75,12 @@ class Area {
     await asyncForEach(this.model.roomIds, async (roomId) => {
       const roomModel = await RoomModel.findById(roomId);
       const room = new Room(roomModel);
-      await room.load();
+      await room.load(0);
       this.rooms.push(room);
+    });
+
+    await asyncForEach(this.rooms, async (room) => {
+      await room.load(1);
     });
   }
 


### PR DESCRIPTION
Prior to this patch, on world load, it was possible for a Room to load a
Spawner and, because that Spawner was trying to track a character that it
had spawned but that had wandered into a Room that was not yet loaded, would
result in the Spawner thinking that the Character no longer existed. The
Spawner would then start spawning more characters. Given enough time and
restarts and Characters not getting killed, you could have a lot of
random Characters walking around.

This patch fixes this by having Rooms go in a two-pass mode. On the
first pass we load all the basic properties and characters; in the second,
the spawners. We actually could go further here and add passes for each
specific thing that references other things in a particular ordering, but
as a basic fix, this works.