### PR TITLE
Look: Allow looking at doors

### DIFF
--- a/src/game/commands/default/Look.js
+++ b/src/game/commands/default/Look.js
@@ -74,15 +74,41 @@ class LookAction {
       }
 
       let item = character.room.inanimates.findItem(this.target);
-      if (!item) {
-        item = character.room.characters.findItem(this.target);
-        if (!item) {
-          character.sendImmediate(`You do not see a ${this.target} here.`);
+      if (item) {
+        character.sendImmediate(item.toLongText());
+        return;
+      }
+
+      item = character.room.characters.findItem(this.target);
+      if (item) {
+        character.sendImmediate(item.toLongText());
+        character.room.sendImmediate([character], `${character.name} looks at ${this.target}`);
+        return;
+      }
+
+      let doorName = this.target;
+      if (doorName.includes('.')) {
+        const tokens = doorName.split('.');
+        const direction = tokens[0];
+        doorName = tokens.slice(1).join(' ');
+        if (!room.exits[direction] || !room.exits[direction].door
+            || room.exits[direction].door.name !== doorName) {
+          character.sendImmediate(`There is no ${doorName} in that direction`);
           return;
         }
-        character.room.sendImmediate([character], `${character.name} looks at ${this.target}`);
+        item = room.exits[direction].door;
+      } else {
+        item = Object.values(room.exits).find(e => e.door && e.door.name === doorName);
+        item = item ? item.door : null;
       }
-      character.sendImmediate(item.toLongText());
+
+      if (item) {
+        character.sendImmediate(item.toLongText());
+        character.room.sendImmediate([character], `${character.name} looks at ${this.target}`);
+        return;
+      }
+
+      character.sendImmediate(`You do not see a ${this.target} here.`);
       return;
     }
   }


### PR DESCRIPTION
This allows the player to start looking at doors, in the same way that
they can look at objects in a room. It sends back a detailed description
of the door, without going into their properties (which is more of an
examine kind of thing).

While we have to do some parsing of the 'direction.{name}' in order to
find a door when there are multiples in a room, I haven't yet decided
if that warrants its own container. We'll definitely need to do that
parsing again for other times when you want to interact with a door
on a particular location, which _is_ going to happen on at least 5 other
actions. So we'll want to stick it somewhere, but it's really all about
just finding the thing in the room you want to interact with. So maybe
just a convenience function at some point.