### PR TITLE
Examine: Allow detailed examinations of doors

### DIFF
--- a/src/game/commands/default/Examine.js
+++ b/src/game/commands/default/Examine.js
@@ -49,6 +49,23 @@ class ExamineAction {
     if (!item) {
       item = character.inanimates.findItem(this.target);
     }
+    if (!item) {
+      let doorName = this.target;
+      if (doorName.includes('.')) {
+        const tokens = doorName.split('.');
+        const direction = tokens[0];
+        doorName = tokens.slice(1).join(' ');
+        if (!character.room.exits[direction] || !character.room.exits[direction].door
+            || character.room.exits[direction].door.name !== doorName) {
+          character.sendImmediate(`There is no ${doorName} in that direction`);
+          return;
+        }
+        item = character.room.exits[direction].door;
+      } else {
+        item = Object.values(character.room.exits).find(e => e.door && e.door.name === doorName);
+        item = item ? item.door : null;
+      }
+    }
 
     if (!item) {
       character.sendImmediate(`You do not see a ${this.target} here.`);

--- a/src/game/objects/Door.js
+++ b/src/game/objects/Door.js
@@ -118,8 +118,17 @@ class Door {
    *
    * @returns {String}
    */
-  toLongText() {
-    return this.model.description;
+  toLongText(character = null) {
+    let description = this.model.description;
+
+    if (character) {
+      description += `\nThe door is ${this.isOpen ? 'open' : 'closed'}.`;
+      if (this.hasLock) {
+        description += ` It is ${this.isLocked ? 'locked' : 'unlocked'}.`;
+      }
+    }
+
+    return description;
   }
 
   /**


### PR DESCRIPTION
There's a few things we're getting repetitive with here:
1. Finding which door we want to examine. This needs to get refactored
   back into something else.

2. I worry about how I'm asserting on message queues. This likely needs
   to get generalized - typically, when we have a bunch of messages
   that a PC has received, we just want to know that they got at least
   one of the messages we expected. Order doesn't matter.