### PR TITLE
Finish adding the currency quest reward

### DIFF
--- a/src/game/characters/quests/CurrencyQuestReward.js
+++ b/src/game/characters/quests/CurrencyQuestReward.js
@@ -40,9 +40,8 @@ class CurrencyQuestReward {
   reward(character, actor, state) {
     const { name, quantity } = this.model.data;
 
-    // NOTE: This is in another branch :-(
-    // We'll come back and finish this up.
-    // actor.currencies.deposit()
+    actor.sendImmediate(`You receive ${quantity} ${name} coin${quantity !== 1 ? 's' : ''} from ${character.toShortText()}.`);
+    actor.currencies.deposit(name, quantity);
   }
 }
 

--- a/test/game/characters/quests/testCurrencyQuestRewards.js
+++ b/test/game/characters/quests/testCurrencyQuestRewards.js
@@ -1,0 +1,66 @@
+//------------------------------------------------------------------------------
+// MJMUD Backend
+// Copyright (C) 2022, Matt Jordan
+//
+// This program is free software, distributed under the terms of the
+// MIT License. See the LICENSE file at the top of the source tree.
+//------------------------------------------------------------------------------
+
+import assert from 'power-assert';
+
+import CurrencyQuestReward from '../../../../src/game/characters/quests/CurrencyQuestReward.js';
+
+describe('CurrencyQuestReward', () => {
+  describe('reward', () => {
+    it('deposits money and displays the right thing when the quantity is 1', () => {
+      let message;
+      let name;
+      let quantity;
+      const uut = new CurrencyQuestReward({ data: { name: 'gold', quantity: 1 }});
+      uut.reward(
+        {
+          toShortText: () => 'test',
+        },
+        {
+          sendImmediate: (msg) => {
+            message = msg;
+          },
+          currencies: {
+            deposit: (n, q) => {
+              name = n;
+              quantity = q;
+            },
+          },
+        }, {});
+      assert(name === 'gold', name);
+      assert(quantity === 1, quantity);
+      assert(message === 'You receive 1 gold coin from test.', message);
+    });
+
+    it('deposits money and displays the right thing when the quantity is >1', () => {
+      let message;
+      let name;
+      let quantity;
+      const uut = new CurrencyQuestReward({ data: { name: 'gold', quantity: 10 }});
+      uut.reward(
+        {
+          toShortText: () => 'test',
+        },
+        {
+          sendImmediate: (msg) => {
+            message = msg;
+          },
+          currencies: {
+            deposit: (n, q) => {
+              name = n;
+              quantity = q;
+            },
+          },
+        }, {});
+      assert(name === 'gold', name);
+      assert(quantity === 10, quantity);
+      assert(message === 'You receive 10 gold coins from test.', message);
+    });
+
+  });
+});

--- a/test/game/characters/quests/testQuest.js
+++ b/test/game/characters/quests/testQuest.js
@@ -39,6 +39,9 @@ class MockCharacter extends EventEmitter {
     this.factions = {
       adjustFaction: () => {},
     };
+    this.currencies = {
+      deposit: () => {},
+    };
   }
 
   getLevel() {
@@ -48,6 +51,8 @@ class MockCharacter extends EventEmitter {
   toShortText() {
     return this.name;
   }
+
+  sendImmediate() {}
 }
 
 describe('Quest', () => {


### PR DESCRIPTION
When we did the quest work, it was tracking an upstream commit that was prior to the merge of currency support. This commit finishes up the current reward. We can now receive money for finishing up a quest.